### PR TITLE
record animations as webm

### DIFF
--- a/src/components/common/Spine/ToolList.vue
+++ b/src/components/common/Spine/ToolList.vue
@@ -28,6 +28,7 @@
         <div>
           <CustomLoader />
         </div>
+        <Recorder />
       </n-card>
     </n-scrollbar>
   </div>
@@ -43,6 +44,7 @@ import BackgroundImagePack from './Tools/BackgroundImagePack.vue'
 import Screenshot from './Tools/Screenshot.vue'
 import ChangeScreenshotSize from './Tools/ChangeScreenshotSize.vue'
 import CustomLoader from './Tools/CustomLoader.vue'
+import Recorder from './Tools/Recorder.vue'
 import { useMarket } from '@/stores/market'
 
 const market = useMarket()

--- a/src/components/common/Spine/Tools/Recorder.vue
+++ b/src/components/common/Spine/Tools/Recorder.vue
@@ -1,0 +1,29 @@
+<template>
+    <div v-if="market.live2d.recorder">
+        <n-button v-if="market.live2d.isRecording" ghost type="success" round @click="stopRecording" >Stop</n-button>
+        <n-button v-else ghost type="success" round @click="startRecording" >Record</n-button>
+
+    </div>
+</template>
+  
+<script setup lang="ts">
+import { useMarket } from '@/stores/market'
+
+const market = useMarket()
+
+const startRecording = () => {
+    market.live2d.recorder?.start()
+}
+
+const stopRecording = () => {
+    market.live2d.recorder?.stop()
+}
+</script>
+  
+<style scoped lang="less">
+.n-button {
+    width: 100%;
+    height: 40px;
+}
+</style>
+  

--- a/src/stores/live2dStore.ts
+++ b/src/stores/live2dStore.ts
@@ -13,6 +13,8 @@ export const useLive2dStore = defineStore('live2d', () => {
   const resetPlacement = ref(0)
   const screenshot = ref(0)
   const hideUI = ref(false)
+  const recorder = ref<MediaRecorder>();
+  const isRecording = ref<boolean>(false);
 
   const fr = new FileReader()
 
@@ -224,6 +226,8 @@ export const useLive2dStore = defineStore('live2d', () => {
     triggerCustomLoad,
     triggerHideUI,
     triggerShowUI,
-    hideUI
+    hideUI,
+    recorder,
+    isRecording
   }
 })


### PR DESCRIPTION
WIP branch for #4 

I hacked together some really basic animation recording capabilities. Yeah, the styling is awful for now. I'm looking for feedback on what the final UI should look like

I added a Record button to the tool list on the right

I was thinking maybe the recordings could get saved in a list and the user can click to playback each one and right click to save. or maybe I add a download button too. The list could just be stored in their browser

I'll need to add controls for bitrate and such. I just used30 FPS and 24 Mbps for fun, but we could give the user more control over it