### PR TITLE
Add export animation functionality.

### DIFF
--- a/src/components/common/Spine/Loader.vue
+++ b/src/components/common/Spine/Loader.vue
@@ -278,8 +278,9 @@ const takeScreenshot = () => {
   link.click()
 }
 
-const RECORDING_MIME_TYPE = 'video/webm'
-const RECORDING_BITRATE = 15000000
+// VP9 may be too performance intensive. VP8 or VP9 MUST be explicitly specified for alpha transparency to work.
+const RECORDING_MIME_TYPE = 'video/webm;codecs=vp8'
+const RECORDING_BITRATE = 5000000
 
 async function startRecording(spinePlayer: any, currentAnimation: string, timestamp: number) {
   return new Promise<void>((resolve, reject) => {

--- a/src/components/common/Spine/Loader.vue
+++ b/src/components/common/Spine/Loader.vue
@@ -9,7 +9,6 @@
 import { onMounted, watch } from 'vue'
 import { useMarket } from '@/stores/market'
 
-// @ts-ignore
 import spine40 from '@/utils/spine/spine-player4.0'
 // @ts-ignore
 import spine41 from '@/utils/spine/spine-player4.1'
@@ -34,6 +33,9 @@ onMounted(() => {
   spineLoader()
   applyDefaultStyle2Canvas()
 })
+
+const SPINE_DEFAULT_MIX = 0.25
+let spinePlayer: any = null
 
 const spineLoader = () => {
   let usedSpine: any
@@ -61,12 +63,14 @@ const spineLoader = () => {
     debug: false,
     preserveDrawingBuffer: true,
     viewport: spineViewport,
-    success: () => {
+    defaultMix: SPINE_DEFAULT_MIX,
+    success: (player: any) => {
+      spinePlayer = player
       successfullyLoaded()
     },
     error: () => {
       wrongfullyLoaded()
-    }
+    },
   })
 }
 
@@ -100,6 +104,7 @@ const customSpineLoader = () => {
     debug: false,
     preserveDrawingBuffer: true,
     viewport: spineViewport,
+    defaultMix: SPINE_DEFAULT_MIX,
     success: (e: any) => {
       successfullyLoaded()
       e.play()
@@ -238,6 +243,12 @@ watch(() => market.live2d.screenshot, () => {
   }
 })
 
+watch(() => market.live2d.exportAnimationTimestamp, (newVal, oldVal) => {
+  if (newVal !== oldVal) {
+    exportAnimationFrames(newVal)
+  }
+})
+
 watch(() => market.live2d.customLoad, () => {
   spineCanvas.dispose()
   market.load.beginLoad()
@@ -265,6 +276,87 @@ const takeScreenshot = () => {
   link.href = dataURL
 
   link.click()
+}
+
+const RECORDING_MIME_TYPE = 'video/webm'
+const RECORDING_BITRATE = 15000000
+
+async function startRecording(spinePlayer: any, currentAnimation: string, timestamp: number) {
+  return new Promise<void>((resolve, reject) => {
+    const chunks = [] // Store recorded media chunks (Blobs)
+    const stream = canvas.captureStream() // Grab our canvas MediaStream
+    const rec = new MediaRecorder(stream, { mimeType: RECORDING_MIME_TYPE, videoBitsPerSecond: RECORDING_BITRATE }) // Initialize the recorder
+
+    rec.onerror = (e) => reject(e) // Reject the promise on error
+
+    // Every time the recorder has new data, store it in our array
+    rec.ondataavailable = (e) => chunks.push(e.data)
+
+    // Only when the recorder stops, construct a complete Blob from all the chunks
+    rec.onstop = async () => {
+      const blob = new Blob(chunks, { type: 'video/webm' })
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.download = 'animation_frames_' + timestamp + '.webm'
+      link.href = url
+      link.click()
+      URL.revokeObjectURL(url) // Clean up
+      resolve()
+    }
+
+    // This is important, the timeslice has to be low or the lag is high and the loop won't look right.
+    rec.start(10)
+
+    spinePlayer.play() // Start the animation
+
+    // Set up an interval to constantly check the condition
+    const checkInterval = setInterval(() => {
+
+      if (spinePlayer.animationState.tracks && spinePlayer.animationState.tracks[0] && spinePlayer.animationState.tracks[0].animationLast !== -1 && spinePlayer.animationState.tracks[0].animationLast === spinePlayer.animationState.tracks[0].animationEnd) {
+        spinePlayer.pause()
+        rec.stop()
+
+        clearInterval(checkInterval)
+      }
+    }, 1) // Check every 1 millisecond
+  })
+}
+
+async function exportAnimationFrames(timestamp: number) {
+  if (spineCanvas && spinePlayer) {
+    const currentAnimation = spineCanvas.config.animation
+    spinePlayer.playerControls.style.visibility = 'hidden'
+    spinePlayer.animationState.data.defaultMix = 0
+    spinePlayer.setAnimation(currentAnimation, false)
+    spinePlayer.pause()
+
+    market.message
+      .getMessage()
+      .success(messagesEnum.MESSAGE_EXPORT_ANIMATION, market.message.short_message)
+
+    market.live2d.isExportingAnimation = true
+    startRecording(spinePlayer, currentAnimation, timestamp).then(() => {
+      market.message
+        .getMessage()
+        .success(messagesEnum.MESSAGE_EXPORT_ANIMATION_SUCCESS, market.message.short_message)
+    }).catch((err: any) => {
+      market.message
+        .getMessage()
+        .error(messagesEnum.MESSAGE_EXPORT_ANIMATION_FAILED, market.message.short_message)
+      console.error(err)
+    }).finally(() => {
+      market.live2d.isExportingAnimation = false
+      spinePlayer.animationState.data.defaultMix = SPINE_DEFAULT_MIX
+      spinePlayer.play()
+      spinePlayer.setAnimation(currentAnimation, true)
+      spinePlayer.playerControls.style.visibility = 'visible'
+    })
+  } else {
+    market.message
+      .getMessage()
+      .error(messagesEnum.MESSAGE_EXPORT_ANIMATION_FAILED, market.message.short_message)
+    console.error('spineCanvas is not properly initialized or accessible.')
+  }
 }
 
 const loadSpineAfterWatcher = () => {

--- a/src/components/common/Spine/ToolList.vue
+++ b/src/components/common/Spine/ToolList.vue
@@ -22,6 +22,9 @@
           <BackgroundImagePack />
         </div>
         <div>
+          <Export />
+        </div>
+        <div>
           <Screenshot />
           <ChangeScreenshotSize />
         </div>
@@ -40,6 +43,7 @@ import HideUI from './Tools/HideUI.vue'
 import BackgroundColor from './Tools/BackgroundColor.vue'
 import BackgroundImage from './Tools/BackgroundImage.vue'
 import BackgroundImagePack from './Tools/BackgroundImagePack.vue'
+import Export from './Tools/Export.vue'
 import Screenshot from './Tools/Screenshot.vue'
 import ChangeScreenshotSize from './Tools/ChangeScreenshotSize.vue'
 import CustomLoader from './Tools/CustomLoader.vue'

--- a/src/components/common/Spine/Tools/Export.vue
+++ b/src/components/common/Spine/Tools/Export.vue
@@ -1,0 +1,22 @@
+<template>
+  <n-button :disabled="market.live2d.isExportingAnimation" ghost type="primary" round @click="capture()">
+    Export
+  </n-button>
+</template>
+
+<script lang="ts" setup>
+import { useMarket } from '@/stores/market'
+
+const market = useMarket()
+
+const capture = () => {
+  market.live2d.exportAnimation()
+}
+</script>
+
+<style lang="less" scoped>
+.n-button {
+  width: 100%;
+  height: 40px;
+}
+</style>

--- a/src/stores/live2dStore.ts
+++ b/src/stores/live2dStore.ts
@@ -11,6 +11,8 @@ export const useLive2dStore = defineStore('live2d', () => {
   const current_spine_version = ref(4.0) as Ref<number>
   const current_pose = ref('fb') as Ref<'fb' | 'aim' | 'cover'>
   const resetPlacement = ref(0)
+  const isExportingAnimation = ref(false)
+  const exportAnimationTimestamp = ref(0)
   const screenshot = ref(0)
   const hideUI = ref(false)
 
@@ -74,6 +76,10 @@ export const useLive2dStore = defineStore('live2d', () => {
 
   const triggerScreenshot = () => {
     screenshot.value = new Date().getTime()
+  }
+
+  const exportAnimation = () => {
+    exportAnimationTimestamp.value = new Date().getTime()
   }
 
   const getSkin = () => {
@@ -208,6 +214,9 @@ export const useLive2dStore = defineStore('live2d', () => {
     triggerResetPlacement,
     screenshot,
     triggerScreenshot,
+    isExportingAnimation,
+    exportAnimationTimestamp,
+    exportAnimation,
     getSkin,
     customSkel,
     initCustomSkel,

--- a/src/utils/enum/globalParams.ts
+++ b/src/utils/enum/globalParams.ts
@@ -34,6 +34,9 @@ enum messagesEnum {
   MESSAGE_TIERLIST_UPDATED_ROW = "Row updated",
   MESSAGE_TIERLIST_SCREENSHOT_CONVERT2CANVAS = "Converting HTML data to a canvas object...",
   MESSAGE_TIERLIST_SCREENSHOT_CANVAS2PNG = "Downloading a canvas to a PNG file",
+  MESSAGE_EXPORT_ANIMATION = "Replaying and exporting animation...",
+  MESSAGE_EXPORT_ANIMATION_SUCCESS = "Animation exported successfully",
+  MESSAGE_EXPORT_ANIMATION_FAILED = "Animation export failed",
 }
 
 enum theme {


### PR DESCRIPTION
A nifty tool to allow for exporting of animations to WebM format with reasonably high quality.

We can add features later to allow for adjusting these settings, quite easily.

This should export with transparency.

Verify with
`ffmpeg -vcodec libvpx -i animation_frames_1710793607332.webm -vf alphaextract -y alpha.mp4`