### PR TITLE
HQ Assets cropping fix

### DIFF
--- a/src/components/common/Spine/Loader.vue
+++ b/src/components/common/Spine/Loader.vue
@@ -416,9 +416,9 @@ const applyDefaultStyle2Canvas = () => {
     if (checkMobile()) {
       setCanvasStyleMobile()
     } else {
-      canvas.style.height = market.live2d.HQassets ? '450vh' : '168vh'
-      canvas.style.marginTop = market.live2d.HQassets ? 'calc(-171vh)' : 'calc(-30vh)'
-      canvas.style.transform = market.live2d.HQassets ? 'scale(0.18)' : 'scale(0.5)'
+      canvas.style.height = market.live2d.HQassets ? '100vh' : '168vh'
+      canvas.style.marginTop = market.live2d.HQassets ? '0' : 'calc(-30vh)'
+      canvas.style.transform = market.live2d.HQassets ? 'scale(0.5)' : 'scale(0.5)'
       canvas.style.position = 'absolute'
       canvas.style.left = '0px'
       canvas.style.top = '0px'


### PR DESCRIPTION
I use a 4k monitor and tweaked a bit on the spine canvas css in the inspector in Chrome on Windows .
I think this could be a easy fix for the HQ assets cropping issue.

Basically clearing the canvas height and margin top should do it. At least worked for me on chrome with browser window resizing in different sizes.
Examples screenshots:
<img width="1863" alt="image" src="https://github.com/user-attachments/assets/25c56ac0-d9f0-475e-8786-23c77fffcbf4">
<img width="1864" alt="image" src="https://github.com/user-attachments/assets/ab3823c4-dcd1-4de1-a328-01bc12d5139d">
<img width="500" alt="image" src="https://github.com/user-attachments/assets/6308c263-f766-4359-b3bd-8ef0b2ec44d4">

The PR is not tested however as I do not have the vue build setup.