### PR TITLE
Regression fixes

### DIFF
--- a/src/components/common/Spine/Loader.vue
+++ b/src/components/common/Spine/Loader.vue
@@ -76,6 +76,8 @@ const resolveAnimation = (requested: string, available: string[]): string | null
     return requested
   }
 
+  if (market.route.name !== 'story-gen') return null
+
   const lowerRequested = requested.toLowerCase()
 
   // Special handling for multi-stage anger (e.g. Chime)

--- a/src/components/views/StoryGenerator.vue
+++ b/src/components/views/StoryGenerator.vue
@@ -10,14 +10,22 @@ import Loader from '@/components/common/Spine/Loader.vue'
 import ChatInterface from '@/components/views/ChatInterface.vue'
 import { theme } from '@/utils/enum/globalParams'
 import { onUnmounted } from 'vue'
+import { onBeforeRouteLeave } from 'vue-router'
 import { useMarket } from '@/stores/market'
 
 const market = useMarket()
 
 market.live2d.current_id = ''
+market.live2d.current_pose = 'fb'
 
 onUnmounted(() => {
   document.body.style.backgroundColor = theme.BACKGROUND_COLOR
+})
+
+onBeforeRouteLeave(() => {
+  market.live2d.current_id = ''
+  market.live2d.current_animation = 'idle'
+  market.live2d.current_pose = 'fb'
 })
 </script>
 


### PR DESCRIPTION
- Resolved a regression that caused the semantic search for animations to trigger in L2D.
- Resolved a regression that caused animations and characters in the Story/Roleplaying Generator to persist if a user clicked on the L2D Visualizer immediately after.
- Fixed an issue that caused the Aim or Cover Mode poses to persist in the Story/Roleplaying Generator if a user clicked on either option in L2D and then decided to generate a story.