### PR TITLE
Hotfix

### DIFF
--- a/src/utils/json/filteredCharacterIds.json
+++ b/src/utils/json/filteredCharacterIds.json
@@ -301,7 +301,8 @@
     "c8004",
     "c8006",
     "c561",
-    "c9009"
+    "c9009",
+    "c018"
   ],
   "_comment": "Characters not in the official playable roster or story animations."
 }


### PR DESCRIPTION
- Fixed Neon appearing with an alternate skin instead of her default one.

@Koshirei I think this is happening because `l2d.json` has duplicate names. I had to filter lots of them that were causing issues in the last update, including some for Rapi, and your last commits have now caused this for Neon. My hotfix should work for now, but I think you'll want to rename duplicate entries in `l2d.json` with different names to avoid this for future characters as well!