### PR TITLE
fix: preserve Pollinations native-search controls after model renames

### DIFF
--- a/src/utils/llmUtils.ts
+++ b/src/utils/llmUtils.ts
@@ -2,6 +2,7 @@
 // These functions handle higher token limits for summarization tasks
 
 import { AIError, logDebug } from '@/utils/chatUtils'
+import { POLLINATIONS_NATIVE_SEARCH_MODELS } from '@/utils/aiWebSearchUtils'
 import { callGeminiSummarization } from '@/utils/geminiUtils'
 import { callPollinationsSummarization } from '@/utils/pollinationsUtils'
 import { modelsWithoutJsonSupport, modelsWithoutReasoningSupport, OPENCODE_GO_CHAT_COMPLETIONS_URL, OPENCODE_GO_MESSAGES_URL, OPENCODE_GO_MODELS_URL, OPENCODE_GO_EXCLUDED_MODEL_IDS, OPENCODE_GO_ANTHROPIC_MODELS, modelsWithoutCacheControlSupport, buildStoryResponseSchema } from '@/utils/providerConfigUtils'
@@ -357,11 +358,11 @@ export const fetchPollinationsModels = async (apiKey?: string) => {
     return models
       .filter((m: any) => {
         const hiddenModels = ['qwen-coder', 'chickytutor', 'midijourney', 'openai-audio']
-        return !hiddenModels.includes(m.name)
+        return ![m.name, ...(m.aliases || [])].some((name: string) => hiddenModels.includes(name))
       })
       .map((m: any) => ({
         label: m.name,
-        value: m.name
+        value: m.aliases?.find((alias: string) => POLLINATIONS_NATIVE_SEARCH_MODELS.includes(alias)) || m.name
       }))
       .sort((a: any, b: any) => a.label.localeCompare(b.label))
   } catch (error) {

--- a/src/utils/pollinationsModels.test.ts
+++ b/src/utils/pollinationsModels.test.ts
@@ -2,7 +2,9 @@ import { afterEach, expect, test, vi } from 'vitest'
 import { fetchPollinationsModels } from './llmUtils'
 import { usesPollinationsAutoFallback } from './aiWebSearchUtils'
 
-afterEach(() => vi.unstubAllGlobals())
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 test('keeps native search controls when the catalog uses canonical names', async () => {
   vi.stubGlobal('fetch', vi.fn().mockResolvedValue({

--- a/src/utils/pollinationsModels.test.ts
+++ b/src/utils/pollinationsModels.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { fetchPollinationsModels } from './llmUtils'
+import { usesPollinationsAutoFallback } from './aiWebSearchUtils'
+
+afterEach(() => vi.unstubAllGlobals())
+
+test('keeps native search controls when the catalog uses canonical names', async () => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => [
+      { name: 'perplexity/sonar', aliases: ['perplexity-fast'] },
+      { name: 'openai/gpt-audio-mini', aliases: ['openai-audio'] },
+      { name: 'openai/gpt-5.4-nano', aliases: ['openai'] }
+    ]
+  }))
+  const models = await fetchPollinationsModels('test-key')
+  expect(models).toEqual([
+    { label: 'openai/gpt-5.4-nano', value: 'openai/gpt-5.4-nano' },
+    { label: 'perplexity/sonar', value: 'perplexity-fast' }
+  ])
+  expect(usesPollinationsAutoFallback('pollinations', models[1].value)).toBe(false)
+  expect(usesPollinationsAutoFallback('pollinations', models[0].value)).toBe(true)
+})
+
+test('keeps legacy and unknown catalog entries unchanged', async () => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => [{ name: 'gemini-search' }, { name: 'new/model' }]
+  }))
+  expect(await fetchPollinationsModels('test-key')).toEqual([
+    { label: 'gemini-search', value: 'gemini-search' },
+    { label: 'new/model', value: 'new/model' }
+  ])
+})


### PR DESCRIPTION
- Pollinations now lists canonical names, while existing IDs remain aliases: https://github.com/pollinations/pollinations/pull/13076.
- Keep the existing native-search alias as the selected value for those models. Otherwise Perplexity/Gemini Search take the wiki fallback path and their search toggle becomes forced on.
- Apply existing hidden-model rules to aliases too; labels still show the canonical name. Reuses the current search-model list; no new mapping table.
- Tests: `npm run test:unit -- --run --threads=false src/utils/pollinationsModels.test.ts` (2 pass; canonical case failed before). Focused ESLint passes.